### PR TITLE
Port label bug fix

### DIFF
--- a/BPG/photonic_objects.py
+++ b/BPG/photonic_objects.py
@@ -1501,3 +1501,40 @@ class PhotonicPinInfo(PinInfo):
 
     def __init__(self, res, **kwargs):
         PinInfo.__init__(self, res, **kwargs)
+
+    @classmethod
+    def from_content(cls,
+                     content,
+                     resolution
+                     ):
+        return PhotonicPinInfo(
+            res=resolution,
+            net_name=content['net_name'],
+            pin_name=content['pin_name'],
+            label=content['label'],
+            layer=content['layer'],
+            bbox=content['bbox'],
+            make_rect=content['make_rect']
+        )
+
+    def transform(self,
+                  loc,
+                  orient,
+                  unit_mode,
+                  copy,
+                  ):
+        new_box = self.bbox.transform(loc=loc, orient=orient, unit_mode=unit_mode)
+        new_box = [[new_box.left, new_box.bottom], [new_box.right, new_box.top]]
+        if copy:
+            self.bbox = new_box
+            return self
+        else:
+            return PhotonicPinInfo(
+                res=self._resolution,
+                net_name=self.net_name,
+                pin_name=self.pin_name,
+                label=self.label,
+                layer=self.layer,
+                bbox=new_box,
+                make_rect=self.make_rect
+            )

--- a/BPG/photonic_port.py
+++ b/BPG/photonic_port.py
@@ -57,6 +57,11 @@ class PhotonicPort:
         self._width_unit = width
         self._orientation = orientation
 
+    def __repr__(self):
+        return "PhotonicPort: name: {}, layer: {}, location: ({}, {})".format(
+            self.name, self.layer, self.center[0], self.center[1]
+        )
+
     @property
     def used(self):
         """Returns True if port is used"""

--- a/BPG/photonic_template.py
+++ b/BPG/photonic_template.py
@@ -18,7 +18,7 @@ from BPG.photonic_core import PhotonicBagLayout
 
 from .photonic_port import PhotonicPort
 from .photonic_objects import PhotonicRect, PhotonicPolygon, PhotonicAdvancedPolygon, PhotonicInstance, PhotonicRound, \
-    PhotonicVia, PhotonicBlockage, PhotonicBoundary, PhotonicPath
+    PhotonicVia, PhotonicBlockage, PhotonicBoundary, PhotonicPath, PhotonicPinInfo
 from BPG import LumericalDesignGenerator
 from collections import OrderedDict
 from BPG.dataprep_gdspy import dataprep_coord_to_gdspy, poly_operation, polyop_gdspy_to_point_list
@@ -769,8 +769,17 @@ class PhotonicTemplateDB(TemplateDB):
 
         # add pins
         for pin in pin_list:
-            # TODO: pins...
-            new_pin_list.append(pin)
+            new_pin_list.append(
+                PhotonicPinInfo.from_content(
+                    content=pin,
+                    resolution=self.grid.resolution
+                ).transform(
+                    loc=loc,
+                    orient=orient,
+                    unit_mode=unit_mode,
+                    copy=False
+                )
+            )
 
         for path in path_list:
             new_path_list.append(


### PR DESCRIPTION
Fixing bug where port labels do not move when instances are not placed at origin. Required transforming the pins when creating a flat content list