### PR TITLE
Fixed label copying issue

### DIFF
--- a/BPG/photonic_objects.py
+++ b/BPG/photonic_objects.py
@@ -1543,9 +1543,6 @@ class PhotonicPinInfo(PinInfo):
         new_box = self.bbox.transform(loc=loc, orient=orient, unit_mode=unit_mode)
         new_box = [[new_box.left, new_box.bottom], [new_box.right, new_box.top]]
         if copy:
-            self.bbox = new_box
-            return self
-        else:
             return PhotonicPinInfo(
                 res=self._resolution,
                 net_name=self.net_name,
@@ -1555,3 +1552,6 @@ class PhotonicPinInfo(PinInfo):
                 bbox=new_box,
                 make_rect=self.make_rect
             )
+        else:
+            self['bbox'] = new_box
+            return self

--- a/tests/test_flatten.py
+++ b/tests/test_flatten.py
@@ -34,6 +34,11 @@ class SubLevel2(BPG.PhotonicTemplateBase):
             unit_mode=False
         )
         self.add_round(circ)
+        self.add_photonic_port(name='Sublevel2',
+                               center=(3, 3),
+                               orient='R0',
+                               layer='SI',
+                               width=1)
 
 
 class SubLevel1(BPG.PhotonicTemplateBase):
@@ -72,6 +77,12 @@ class SubLevel1(BPG.PhotonicTemplateBase):
             orient='R180'
         )
 
+        self.add_photonic_port(name='Sublevel1',
+                               center=(2, 6),
+                               orient='R0',
+                               layer='SI',
+                               width=1)
+
 
 class TopLevel(BPG.PhotonicTemplateBase):
     def __init__(self, temp_db,
@@ -102,6 +113,11 @@ class TopLevel(BPG.PhotonicTemplateBase):
             coord2=(6, 6),
             unit_mode=False
         )
+        self.add_photonic_port(name='TopLevel',
+                               center=(6, 6),
+                               orient='R0',
+                               layer='SI',
+                               width=1)
 
         sub_master = self.new_template(params={}, temp_cls=SubLevel1)
 


### PR DESCRIPTION
Labels were being copied when `PhotonicPinInfo.transform()` copy parameter is false. Also found a bug where the new bbox for the pin shape was not being stored appropriately.