### PR TITLE
Adding ability to filter out annoying BPG log messages. 

### DIFF
--- a/BPG/logger.py
+++ b/BPG/logger.py
@@ -2,6 +2,9 @@ import logging
 from datetime import datetime
 import atexit
 import sys
+import BPG
+import re
+
 
 def setup_logger(log_path: str,
                  log_filename: str = 'bpg.log',
@@ -140,23 +143,28 @@ def setup_logger(log_path: str,
         duplicate_filter.clear_history()
 
 
-class DontRepeatFilter:
+class DontRepeatFilter(logging.Filter):
     def __init__(self):
-        self.dont_repeat_filters = {
-            "vias are currently not considered in master bounding box calculations": 0,
-            "round bounding boxes currently overestimate the size": 0
-        }
+        logging.Filter.__init__(self, 'DontRepeatFilter')
+        excludes = BPG.run_settings['bpg_config'].get('duplicate_filter_excludes', [])
+        self.dont_repeat_filters = dict()
+        for pattern in excludes:
+            self.dont_repeat_filters[pattern] = 0
+
+        # Make a regex that matches if any of our regexes match.
+        self.combined_regex = "(" + ")|(".join(excludes) + ")"
 
     def filter(self, record):
-        if record.msg not in self.dont_repeat_filters:
+        if not re.match(self.combined_regex, record.msg):
             return True
         else:
-            if self.dont_repeat_filters[record.msg] == 0:
-                self.dont_repeat_filters[record.msg] += 1
-                record.msg = '\n'.join([record.msg, 'ATTENTION: THE ABOVE WARNING WILL NOT BE REPEATED'])
-                return True
-            else:
-                return False
+            return False
+            # if self.dont_repeat_filters[record.msg] == 0:
+            #     self.dont_repeat_filters[record.msg] += 1
+            #     record.msg = '\n'.join([record.msg, 'ATTENTION: THE ABOVE WARNING WILL NOT BE REPEATED'])
+            #     return True
+            # else:
+            #     return False
 
     def clear_history(self):
         for key in self.dont_repeat_filters:

--- a/BPG/logger.py
+++ b/BPG/logger.py
@@ -51,7 +51,7 @@ def setup_logger(log_path: str,
     # Add filter to prevent dataprep debug logs from hitting the main logger
 
     # Add filter to prevent duplicates of annoying messages
-    duplicate_filter = DontRepeatFilter()
+    duplicate_filter = WarningFilter()
     out_handler.addFilter(duplicate_filter)
 
     # Print out the current date and time
@@ -143,16 +143,16 @@ def setup_logger(log_path: str,
         duplicate_filter.clear_history()
 
 
-class DontRepeatFilter(logging.Filter):
+class WarningFilter(logging.Filter):
     def __init__(self):
-        logging.Filter.__init__(self, 'DontRepeatFilter')
-        excludes = BPG.run_settings['bpg_config'].get('duplicate_filter_excludes', [])
-        self.dont_repeat_filters = dict()
-        for pattern in excludes:
-            self.dont_repeat_filters[pattern] = 0
+        logging.Filter.__init__(self, 'WarningFilter')
+        filters = BPG.run_settings['bpg_config'].get('warning_filters', [])
+        self.filter_dict = dict()
+        for pattern in filters:
+            self.filter_dict[pattern] = 0
 
         # Make a regex that matches if any of our regexes match.
-        self.combined_regex = "(" + ")|(".join(excludes) + ")"
+        self.combined_regex = "(" + ")|(".join(filters) + ")"
 
     def filter(self, record):
         if not re.match(self.combined_regex, record.msg):
@@ -167,8 +167,8 @@ class DontRepeatFilter(logging.Filter):
             #     return False
 
     def clear_history(self):
-        for key in self.dont_repeat_filters:
-            self.dont_repeat_filters[key] = 0
+        for key in self.filter_dict:
+            self.filter_dict[key] = 0
 
     def add_key(self, key):
-        self.dont_repeat_filters[key] = 0
+        self.filter_dict[key] = 0


### PR DESCRIPTION
Add a key to bpg_config inside of bag_config.yaml called 'duplicate_filter_exclude'. 
The value of this key is a list of regex-ed strings (so .* is allowed, etc)

ie:

```
bpg_config:
  photonic_tech_config_path: "..."
  duplicate_filter_exclude:
    - "round bounding boxes currently overestimate the size"
    - "Attempted to generate a waveguide with near-zero length.*"
```