### PR TITLE
new method: new_template_with_spec_file under template.py

### DIFF
--- a/BPG/template.py
+++ b/BPG/template.py
@@ -5,6 +5,8 @@ import logging
 import math
 import copy
 import warnings
+import importlib
+import yaml
 
 # bag imports
 import bag.io
@@ -984,17 +986,26 @@ class PhotonicTemplateBase(TemplateBase, metaclass=abc.ABCMeta):
 
 
 
-    def new_template_with_yaml_params(self, 
-                                      path_to_yaml,
-                                      temp_cls,
-                                      **kwargs):
+    def new_template_with_spec_file(self, 
+                                    path_to_yaml,
+                                    **kwargs):
         """
         """
         #
-        with open( path_to_yaml ) as this_yaml_file:
-            this_yaml_file = yaml.load(this_file)
-        temp_cls = copy.deepcopy(this_yaml_file['layout_package'])
-        params = copy.deepcopy(this_yaml_file['layout_params'])
+        # Should I care about unsafe load?
+        with open( path_to_yaml ) as yaml_file:
+            yaml_file_load = yaml.load(yaml_file)
+
+        photonic_module = importlib.import_module(yaml_file_load['layout_package'])
+        photonic_class = yaml_file_load['layout_class']
+        temp_cls = getattr(photonic_module, photonic_class)
+
+        #params = copy.deepcopy(yaml_file_load['layout_params'])
+        params = yaml_file_load['layout_params']
+
+        #import pdb
+        #pdb.set_trace()
+
         return TemplateBase.new_template(self,
                                          params=params,
                                          temp_cls=temp_cls,

--- a/BPG/template.py
+++ b/BPG/template.py
@@ -1000,7 +1000,7 @@ class PhotonicTemplateBase(TemplateBase, metaclass=abc.ABCMeta):
         Parameters
         ----------
         path_to_yaml : string
-            (absolute or relative) path to 
+            (absolute or relative from run directory) path to yaml spec file
         kwargs : dict
             a dictionary of new parameter values
 
@@ -1024,8 +1024,11 @@ class PhotonicTemplateBase(TemplateBase, metaclass=abc.ABCMeta):
             if key in new_params:
                 new_params[key] = val
 
-        #import pdb
-        #pdb.set_trace()
+        # TODO: Handling exceptions 
+        # 1. If module, class not found, show what file is being broken
+        # 2. when kwargs is not empty but only have wrong keys, raise Error
+        # Not necessary, most are automatically handled by new_template method
+
         return TemplateBase.new_template(self,
                                          params=new_params,
                                          temp_cls=temp_cls,

--- a/BPG/template.py
+++ b/BPG/template.py
@@ -990,24 +990,44 @@ class PhotonicTemplateBase(TemplateBase, metaclass=abc.ABCMeta):
                                     path_to_yaml,
                                     **kwargs):
         """
+        Create a new template from the spec file
+
+        This method will load the spec file, reads the layout class and parameters, then create a new template with those.
+        It can also update the parameter values if appropriately given as kwargs.
+        The procedure is useful in the context of reusing the large spec file, enabling the device design choices to be kept within a few yaml files and thus hierarchically managed.
+        Written as a simple wrapper method for new_template
+
+        Parameters
+        ----------
+        path_to_yaml : string
+            (absolute or relative) path to 
+        kwargs : dict
+            a dictionary of new parameter values
+
+        Returns
+        -------
+        master : PhotonicTemplateBase
+            Newly created master from the given spec file
         """
-        #
-        # Should I care about unsafe load?
+        # yaml-written spec file load
         with open( path_to_yaml ) as yaml_file:
             yaml_file_load = yaml.load(yaml_file)
 
+        # auto type-in the template class
         photonic_module = importlib.import_module(yaml_file_load['layout_package'])
         photonic_class = yaml_file_load['layout_class']
         temp_cls = getattr(photonic_module, photonic_class)
 
-        #params = copy.deepcopy(yaml_file_load['layout_params'])
-        params = yaml_file_load['layout_params']
+        # Create a new parameter dictionary based on the provided changes
+        new_params = copy.deepcopy(yaml_file_load['layout_params'])
+        for key, val in kwargs.items():
+            if key in new_params:
+                new_params[key] = val
 
         #import pdb
         #pdb.set_trace()
-
         return TemplateBase.new_template(self,
-                                         params=params,
+                                         params=new_params,
                                          temp_cls=temp_cls,
                                          **kwargs
                                          )

--- a/BPG/template.py
+++ b/BPG/template.py
@@ -982,3 +982,21 @@ class PhotonicTemplateBase(TemplateBase, metaclass=abc.ABCMeta):
                                          **kwargs
                                          )
 
+
+
+    def new_template_with_yaml_params(self, 
+                                      path_to_yaml,
+                                      temp_cls,
+                                      **kwargs):
+        """
+        """
+        #
+        with open( path_to_yaml ) as this_yaml_file:
+            this_yaml_file = yaml.load(this_file)
+        temp_cls = copy.deepcopy(this_yaml_file['layout_package'])
+        params = copy.deepcopy(this_yaml_file['layout_params'])
+        return TemplateBase.new_template(self,
+                                         params=params,
+                                         temp_cls=temp_cls,
+                                         **kwargs
+                                         )


### PR DESCRIPTION
Simply put, a wrapper method for new_template to be able to load the module/class/parameters from the pre-written yaml spec file
Explanation:
       This method will load the spec file, reads the layout class and parameters, then create a new template with those.
        It can also update the parameter values if appropriately given as kwargs.
        The procedure is useful in the context of reusing the large spec file, enabling the device design choices to be kept within a few yaml files and thus hierarchically managed.
        Written as a simple wrapper method for new_template

Caveat: exception handlings not implemented, since most of them are handled by built-in exceptions (AttributeError from class-missing errors, FileLoadError from yaml file missing, etc) and BPG exception classes (new_template method)

Also, this commit includes few additional module calls inside template.py: importlib, yaml